### PR TITLE
Version 0.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ config.js*
 channels.json
 ignore.json
 index.yaml
+npm-debug.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 0.5.0
+- Adds support for specifying an "offset" in the web interface.
+- API for messages now allows query parameters instead of headers.
+    - Headers are still allowed to keep it backwards-compatible.
+- API now allows messages to be returned in "plaintext", by specifying `plain` as a query parameter or header.
+
 ## Version 0.4.2
 - Fix error when ignore list for channel did not exist.
 - Fix minor error in home view for handling errors.

--- a/helpers.js
+++ b/helpers.js
@@ -22,4 +22,47 @@ helpers.now = () => {
     return date.join(" ") + " UTC";
 };
 
+/**
+ * Formats the timestamp into a UTC date.
+ *
+ * @param  {Mixed} timestamp The timestamp to format.
+ * @return {String}          The formatted date.
+ */
+helpers.formatDate = (timestamp) => {
+    timestamp = parseInt(timestamp);
+
+    let date = new Date(timestamp).toUTCString().split(" ");
+    date.shift();
+    date.pop();
+
+    return date.join(" ");
+};
+
+/**
+ * Retrieves either the header or query parameter value from the request.
+ *
+ * @param  {Object} req  The request object.
+ * @param  {String} name The name of the header/query parameter.
+ * @return {Mixed}       The value or undefined.
+ */
+helpers.requestValue = (req, name) => {
+    return (typeof req.query[name] !== 'undefined' ? req.query[name] : req.get(name));
+};
+
+/**
+ * Returns the proper response based on the input value.
+ *
+ * @param  {Object} res   The express response object.
+ * @param  {Mixed} value  The value to send back in the response.
+ * @return {Mixed}
+ */
+helpers.response = (res, value) => {
+    if (typeof value !== 'object') {
+        res.setHeader('Content-Type', 'text/plain');
+        return res.send(value);
+    }
+
+    return res.json(value);
+};
+
 module.exports = helpers;

--- a/views/base.html
+++ b/views/base.html
@@ -27,6 +27,7 @@
 
                 <ul class="nav navbar-nav">
                     <li><a href="#"><i class="fa fa-1x fa-home"></i> Home</a></li>
+                    <li><a href="https://github.com/Decicus/twitch-log-bot"><i class="fa fa-1x fa-github"></i> GitHub</a></li>
                 </ul>
             </div>
         </nav>

--- a/views/home.html
+++ b/views/home.html
@@ -25,6 +25,11 @@
             <input type="number" class="form-control" step="1" min="1" value="25" id="limit" onchange="update();">
         </div>
 
+        <div class="form-group">
+            <label for="offset"><i class="fa fa-sort-numeric-desc fa-1x"></i> Amount of messages to offset by:</label>
+            <input type="number" class="form-control" step="1" min="0" value="0" id="offset" onchange="update();">
+        </div>
+
         <div class="alert alert-danger hidden" id="error"></div>
 
         <div class="hidden alert alert-success"><i class="fa fa-comments-o fa-1x"></i> Retrieved <strong id="count"></strong> messages</div>
@@ -113,6 +118,7 @@
             updating = true;
 
             var limit = parseInt(value('#limit'));
+            var offset = parseInt(value('#offset'));
 
             var messages = $('#messages');
             messages.before('<p class="text-warning" id="loading">Loading...</p>');
@@ -146,7 +152,8 @@
                 headers: {
                     channel: channel,
                     user: username,
-                    limit: limit
+                    limit: limit,
+                    offset: offset
                 },
                 dataType: "json",
                 success: function (data) {

--- a/views/home.html
+++ b/views/home.html
@@ -27,6 +27,7 @@
 
         <div class="alert alert-danger hidden" id="error"></div>
 
+        <div class="hidden alert alert-success"><i class="fa fa-comments-o fa-1x"></i> Retrieved <strong id="count"></strong> messages</div>
         <table id="messages" class="table table-bordered hidden">
             <thead>
                 <tr>
@@ -117,6 +118,8 @@
             messages.before('<p class="text-warning" id="loading">Loading...</p>');
             var loading = $('#loading');
             var refresh = $('#refresh');
+            var count = $('#count');
+            var countP = count.parent('div');
 
             if (!messages.hasClass('hidden')) {
                 messages.addClass('hidden');
@@ -133,6 +136,10 @@
                 refresh.addClass('disabled');
             }
 
+            if (!countP.hasClass('hidden')) {
+                countP.addClass('hidden');
+            }
+
             $('.fa', refresh).addClass('fa-spin');
             $.ajax({
                 url: '/api/messages',
@@ -143,7 +150,6 @@
                 },
                 dataType: "json",
                 success: function (data) {
-                    messages.removeClass('hidden');
                     if (data.success) {
                         var msgs = data.messages;
                         msgs.forEach(function (md) {
@@ -155,6 +161,9 @@
                                 .html('<th>' + date.join(" ") + '</th><td>' +  md.channel +'</td><td>' + md.user.display_name + '</td><td>' + htmlEntities(md.message) + '</td>')
                                 .appendTo('tbody', messages);
                         });
+                        messages.removeClass('hidden');
+                        countP.removeClass('hidden');
+                        count.html(data.count);
                     } else {
                         error(data.error);
                     }


### PR DESCRIPTION
From the changelog:

- Adds support for specifying an "offset" in the web interface.
- API for messages now allows query parameters instead of headers.
    - Headers are still allowed to keep it backwards-compatible.
- API now allows messages to be returned in "plaintext", by specifying `plain` as a query parameter or header.