### PR TITLE
Update lookups to use user IDs

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,4 @@
+{
+    "esversion": 6,
+    "node": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.7.0
+- Lookups are now done via user IDs instead of names. This will account for users that have changed their names.
+
 ## Version 0.6.0
 - Added support for logging resub messages. The format is currently:
     - `Resub (X months) - Message: MSG`

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ If you want something that has more features, take a look at [CBenni's Logviewer
 - Copy `index.sample.yaml` to `index.yaml` and edit each `kind` to what you wish to store it as in Google Cloud Datastore. Anything else should (by default) be left as-is.
     - The easiest way to create these indexes is by installing [Google Cloud SDK](https://cloud.google.com/sdk/), then running `gcloud init` after installing.
     - After that, while being in the directory of this bot, run `gcloud preview datastore create-indexes index.yaml` and it should create the indexes.
+    - If you wanna make sure you don't have unnecessary indexes on GC Datastore, run `gcloud preview datastore cleanup-indexes index.yaml` in the same directory.
 - Copy `channels.sample.json` to `channels.json` and edit it.
     - **It's recommended to at least remove the example channels**.
 - Copy `ignore.sample.json` to `ignore.json`.

--- a/app.js
+++ b/app.js
@@ -596,3 +596,13 @@ if (settings.express.enabled) {
 }
 
 client.connect();
+
+process.on('SIGINT', () => {
+    client.disconnect()
+        .then(() => {
+            console.log('Successfully disconnected from Twitch chat server.');
+        })
+        .catch((err) => {
+            console.error(`Error occurred disconnecting from Twitch chat server: ${err}`);
+        });
+});

--- a/config.sample.js
+++ b/config.sample.js
@@ -67,7 +67,11 @@ config.settings = {
         enabled: false,
         // What port to run the express/web server on
         port: 8000
-    }
+    },
+    // Twitch API stuff.
+    twitch: {
+        clientId: ''
+    },
 };
 
 module.exports = config;

--- a/index.sample.yaml
+++ b/index.sample.yaml
@@ -9,12 +9,12 @@ indexes:
 - kind: twitch-log-bot
   properties:
   - name: channel
-  - name: username
+  - name: user_id
   - name: timestamp
     direction: desc
 
 - kind: twitch-log-bot
   properties:
-    - name: username
+    - name: user_id
     - name: timestamp
       direction: desc

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitch-log-bot",
-  "version": "0.5.1",
+  "version": "0.7.0",
   "description": "Twitch logging with Google Cloud Datastore",
   "main": "app.js",
   "scripts": {
@@ -11,6 +11,7 @@
   "dependencies": {
     "@google-cloud/datastore": "^0.5.0",
     "express": "^4.14.0",
+    "request": "^2.81.0",
     "swig": "^1.4.2",
     "tmi.js": "^1.1.2"
   },


### PR DESCRIPTION
Currently the web interface/API doesn't work correctly, because lookups are done using usernames/channel names.

This will solve that issue, by looking up the user ID by the username first, caching it (for the period the app runs) and then checking GC Datastore using that user ID.
This also prevents multiple calls for the same user.